### PR TITLE
rgw: Fix race conditions on FIFO journal entries

### DIFF
--- a/src/cls/fifo/cls_fifo_types.h
+++ b/src/cls/fifo/cls_fifo_types.h
@@ -62,10 +62,6 @@ struct objv {
     return (instance != rhs.instance ||
 	    ver != rhs.ver);
   }
-  bool operator <(const objv& rhs) const {
-    return (instance == rhs.instance &&
-	    ver < rhs.ver);
-  }
   bool same_or_later(const objv& rhs) const {
     return (instance == rhs.instance &&
 	    ver >= rhs.ver);

--- a/src/cls/fifo/cls_fifo_types.h
+++ b/src/cls/fifo/cls_fifo_types.h
@@ -62,6 +62,10 @@ struct objv {
     return (instance != rhs.instance ||
 	    ver != rhs.ver);
   }
+  bool operator <(const objv& rhs) const {
+    return (instance == rhs.instance &&
+	    ver < rhs.ver);
+  }
   bool same_or_later(const objv& rhs) const {
     return (instance == rhs.instance &&
 	    ver >= rhs.ver);
@@ -385,6 +389,16 @@ struct info {
 
     for (const auto& entry : update.journal_entries_add()) {
       using enum journal_entry::Op;
+
+      if ((entry.op == create && entry.part_num == max_push_part_num)
+	|| (entry.op == set_head && entry.part_num == head_part_num)) {
+	if (errmsg) {
+	  *errmsg = fmt::format("Repeated operationis are not allowed, "
+				"part num={}", entry.part_num);
+	}
+	return -ECANCELED;
+      }
+
       auto iter = target.journal.find(entry.part_num);
       if (iter != target.journal.end() &&
 	  iter->second.op == entry.op) {

--- a/src/rgw/cls_fifo_legacy.cc
+++ b/src/rgw/cls_fifo_legacy.cc
@@ -441,12 +441,7 @@ int FIFO::apply_update(const DoutPrefixProvider *dpp,
 		 << " entering: tid=" << tid << dendl;
   std::unique_lock l(m);
 
-  if (objv < info->version) {
-    ldpp_dout(dpp, 0) << __PRETTY_FUNCTION__ << ":" << __LINE__
-		      << " a newer version is available. use the newer version. tid="
-		      << tid << dendl;
-    return 0;
-  } else if (objv != info->version) {
+  if (objv != info->version) {
     ldpp_dout(dpp, -1) << __PRETTY_FUNCTION__ << ":" << __LINE__
 		       << " version mismatch, canceling: tid=" << tid << dendl;
     return -ECANCELED;
@@ -792,12 +787,6 @@ int FIFO::_prepare_new_part(const DoutPrefixProvider *dpp,
     if (r >= 0 && canceled) {
       std::unique_lock l(m);
       version = info.version;
-      if (new_part_num <= info.max_push_part_num) {
-	ldpp_dout(dpp, 0) << __PRETTY_FUNCTION__ << ":" << __LINE__
-		       << " raced, but processed: i=" << i
-		       << " tid=" << tid << dendl;
-	return 0;
-      }
       auto found = (info.journal.find(new_part_num) != info.journal.end());
       if ((info.max_push_part_num >= new_part_num &&
 	   info.head_part_num >= new_part_num)) {
@@ -885,12 +874,6 @@ int FIFO::_prepare_new_head(const DoutPrefixProvider *dpp,
       std::unique_lock l(m);
       auto iter = info.journal.find(new_head_part_num);
       version = info.version;
-      if (!info.need_new_head()) {
-	ldpp_dout(dpp, 0) << __PRETTY_FUNCTION__ << ":" << __LINE__
-		       << " raced, but processed: i=" << i
-		       << " tid=" << tid << dendl;
-	return 0;
-      }
       bool found = iter != info.journal.cend() && iter->second.op == set_head;
       if ((info.head_part_num >= new_head_part_num)) {
 	ldpp_dout(dpp, 20) << __PRETTY_FUNCTION__ << ":" << __LINE__


### PR DESCRIPTION
Block some repeated metadata update to avoid some race conditions on FIFO journal entries.

Fixes: [https://tracker.ceph.com/issues/57562](https://tracker.ceph.com/issues/57562)
Signed-off-by: Jane Zhu [jzhu116@bloomberg.net](mailto:jzhu116@bloomberg.net)

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>

