### PR TITLE
Wrap the create head into a lock

### DIFF
--- a/src/rgw/cls_fifo_legacy.cc
+++ b/src/rgw/cls_fifo_legacy.cc
@@ -1550,7 +1550,6 @@ struct Pusher : public Completion<Pusher> {
   void new_head(const DoutPrefixProvider *dpp, Ptr&& p) {
     new_heading = true;
     f->_prepare_new_head(dpp, head_part_num + 1, tid, call(std::move(p)));
-    l2.unlock();
   }
 
   void handle(const DoutPrefixProvider *dpp, Ptr&& p, int r) {


### PR DESCRIPTION
In current testing the issue we are seeing is different THREADS are succeeding in creating the same part but different version number, resulting in mismatch version and hence eventual datalog writes to that part is failing.
Of all the testing we have done, this issue is happening on same the RGW instances with multiple threads, the multi instances RGW issue is already been taken care by the changes in cls_fifo_types.h.
So to address this issue, i just added the new head/part creation under a lock, and was able to run the test successfully without missing objects.
Currently as part of create new head inside cls_legacy_fifo.cc, we intermittently hold locks inside functions (_prepare_new_head --> _prepare_new_part --> update_meta --> apply_update --> process_journal --> create_part -> update_meta --> apply_udpate). Because of intermittent locks, often the other thread is sneaking in and succeeding in creating new thread with different version even after all checks.
So as part of fix i am just locking the entire creation of prepare_new_head under the lock, so multiple instances cannot create the same part at same time.